### PR TITLE
Fix duplicate dependency and plugin declarations in enforcer-rules

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -535,6 +535,7 @@
                             <phase>${maven-enforcer-plugin.phase}</phase>
                             <configuration>
                                 <rules>
+                                    <banDuplicatePomDependencyVersions/>
                                     <dependencyConvergence/>
                                     <externalRules>
                                         <location>classpath:enforcer-rules/quarkus-banned-dependencies.xml</location>

--- a/extensions/opentelemetry/deployment/pom.xml
+++ b/extensions/opentelemetry/deployment/pom.xml
@@ -164,11 +164,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-logging</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
             <scope>test</scope>

--- a/independent-projects/enforcer-rules/pom.xml
+++ b/independent-projects/enforcer-rules/pom.xml
@@ -82,18 +82,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>${maven-core.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven-core.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
             <version>${aether.version}</version>
@@ -109,20 +97,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.eclipse.sisu</groupId>
-                <artifactId>sisu-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <id>index-project</id>
-                        <goals>
-                            <goal>main-index</goal>
-                            <goal>test-index</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Remove duplicate `maven-artifact` and `maven-model` dependency declarations in `independent-projects/enforcer-rules/pom.xml`
- Remove duplicate `sisu-maven-plugin` plugin declaration in the same file
- Add `banDuplicatePomDependencyVersions` enforcer rule to `build-parent/pom.xml` to prevent duplicate dependencies from being introduced in the future

These duplicates caused Maven build warnings:
```
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.maven:maven-artifact:jar
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.maven:maven-model:jar
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.eclipse.sisu:sisu-maven-plugin
```

## Test plan
- [x] `mvn validate -f independent-projects/enforcer-rules/pom.xml` passes with no warnings
- [x] `mvn validate -f build-parent/pom.xml -N` passes and `BanDuplicatePomDependencyVersions` rule runs successfully